### PR TITLE
Add pull_blocked command (fixes #9185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Key commands:
 - `last_week_listens`: Lists 12-inch records listened to in the last week, ordered by score.
 - `listsales`: Lists all records currently listed for sale.
 - `bad_sales`: Lists records for sale that are blocked from sale on Discogs.
+- `pull_blocked`: Lists sold records that were physically removed from active sale due to being blocked.
 
 ## Development
 

--- a/recordcollection_cli/cli.go
+++ b/recordcollection_cli/cli.go
@@ -846,6 +846,28 @@ func main() {
 				fmt.Printf("%v %v [%v] BLOCKED\n", i, r.GetRecord().GetRelease().GetInstanceId(), r.GetRecord().GetRelease().GetTitle())
 			}
 		}
+	case "pull_blocked":
+		var totalIds []int32
+		
+		for _, cat := range []pbrc.ReleaseMetadata_Category{pbrc.ReleaseMetadata_SOLD_OFFLINE, pbrc.ReleaseMetadata_SOLD, pbrc.ReleaseMetadata_SOLD_ARCHIVE} {
+			ids, err := registry.QueryRecords(ctx, &pbrc.QueryRecordsRequest{Query: &pbrc.QueryRecordsRequest_Category{cat}})
+			if err != nil {
+				fmt.Printf("Error %v\n", err)
+				continue
+			}
+			totalIds = append(totalIds, ids.GetInstanceIds()...)
+		}
+
+		for i, id := range totalIds {
+			r, err := registry.GetRecord(ctx, &pbrc.GetRecordRequest{InstanceId: id})
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				continue
+			}
+			if r.GetRecord().GetRelease().GetBlockedFromSale() {
+				fmt.Printf("%v %v [%v] BLOCKED\n", i, r.GetRecord().GetRelease().GetInstanceId(), r.GetRecord().GetRelease().GetTitle())
+			}
+		}
 	case "run_full_update":
 		ids, err := registry.QueryRecords(ctx, &pbrc.QueryRecordsRequest{Query: &pbrc.QueryRecordsRequest_UpdateTime{0}})
 		if err != nil {


### PR DESCRIPTION
Implementation of the pull_blocked command to query sold/sold offline records that were physically removed due to being blocked.