### PR TITLE
Implement cleanAndValidateIids helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
     - Physical dimensions (spine width, weight).
     - Condition tracking (media and sleeve).
     - Custom categories and "purgatory" states (needs labels, needs rip, etc.).
+    - **IID Validation & Cleaning**: Private helper to clean and validate internal instance IDs (IIDs), converting negative values to their positive representations and filtering out invalid IDs.
+
 - **Automated Sale Management**:
     - **Listing Generation**: Integrates with an external gRPC service to automatically generate rich, descriptive sale listings based on record condition and user notes.
     - **Dynamic Pricing**: Tracks and updates sale prices based on market data.

--- a/recordcollectionapi.go
+++ b/recordcollectionapi.go
@@ -902,3 +902,17 @@ func (s *Server) GetPrice(ctx context.Context, req *pb.GetPriceRequest) (*pb.Get
 	price, err := s.retr.GetSalePrice(ctx, int(req.GetId()))
 	return &pb.GetPriceResponse{Price: price}, err
 }
+
+func cleanAndValidateIids(ids []int64) []int64 {
+	cleaned := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if id < 0 {
+			id = int64(uint32(id))
+		}
+		if id >= 0 {
+			cleaned = append(cleaned, id)
+		}
+	}
+	return cleaned
+}
+

--- a/recordcollectionapi_test.go
+++ b/recordcollectionapi_test.go
@@ -688,3 +688,21 @@ func TestQueryRecordsWithListenTime(t *testing.T) {
 		t.Errorf("Wrong record returned: %v", q.GetInstanceIds()[0])
 	}
 }
+
+func TestCleanAndValidateIids(t *testing.T) {
+	input := []int64{123, -1, 456, -456, 0}
+	expected := []int64{123, 4294967295, 456, 4294966840, 0}
+
+	output := cleanAndValidateIids(input)
+
+	if len(output) != len(expected) {
+		t.Fatalf("Expected slice length %v, got %v", len(expected), len(output))
+	}
+
+	for i, v := range output {
+		if v != expected[i] {
+			t.Errorf("At index %d: expected %v, got %v", i, expected[i], v)
+		}
+	}
+}
+


### PR DESCRIPTION
Closes #9198. Part of parent issue #9197. Implements the cleanAndValidateIids helper function to clean and validate internal instance IDs.