### PR TITLE
Refactor QueryRecords to clean and validate instance IDs

### DIFF
--- a/recordcollectionapi.go
+++ b/recordcollectionapi.go
@@ -747,66 +747,61 @@ func (s *Server) QueryRecords(ctx context.Context, req *pb.QueryRecordsRequest) 
 
 	case *pb.QueryRecordsRequest_ListenTime:
 		for id, _ := range collection.InstanceToUpdate {
-			record, err := s.loadRecord(ctx, int64(id), false)
+			record, err := s.loadRecord(ctx, id, false)
 			if err != nil {
 				return nil, err
 			}
 			if record.GetMetadata().GetLastListenTime() >= x.ListenTime {
-				ids = append(ids, int64(int32(id)))
+				ids = append(ids, id)
 			}
 		}
-		return &pb.QueryRecordsResponse{InstanceIds: ids}, nil
 
 	case *pb.QueryRecordsRequest_FolderId:
 		for id, folder := range collection.GetInstanceToFolder() {
 			if folder == x.FolderId {
-				ids = append(ids, int64(int32(id)))
+				ids = append(ids, id)
 			}
 		}
-
-		return &pb.QueryRecordsResponse{InstanceIds: ids}, nil
 
 	case *pb.QueryRecordsRequest_UpdateTime:
 		for id, updateTime := range collection.InstanceToUpdate {
 			if updateTime >= x.UpdateTime {
-				ids = append(ids, int64(int32(id)))
+				ids = append(ids, id)
 			}
 		}
-		return &pb.QueryRecordsResponse{InstanceIds: ids}, nil
 
 	case *pb.QueryRecordsRequest_Category:
 		for id, category := range collection.GetInstanceToCategory() {
 			if category == x.Category {
-				ids = append(ids, int64(int32(id)))
+				ids = append(ids, id)
 			}
 		}
-		return &pb.QueryRecordsResponse{InstanceIds: ids}, nil
 
 	case *pb.QueryRecordsRequest_MasterId:
 		for id, masterID := range collection.InstanceToMaster {
 			if masterID == x.MasterId {
-				ids = append(ids, int64(int32(id)))
+				ids = append(ids, id)
 			}
 		}
-		return &pb.QueryRecordsResponse{InstanceIds: ids}, nil
 
 	case *pb.QueryRecordsRequest_ReleaseId:
 		for id, releaseID := range collection.GetInstanceToId() {
 			if releaseID == x.ReleaseId {
-				ids = append(ids, int64(int32(id)))
+				ids = append(ids, id)
 			}
 		}
-		return &pb.QueryRecordsResponse{InstanceIds: ids}, nil
 
 	case *pb.QueryRecordsRequest_All:
 		coll := s.retr.GetCollection(ctx)
 		for _, rel := range coll {
 			ids = append(ids, rel.GetInstanceId())
 		}
-		return &pb.QueryRecordsResponse{InstanceIds: ids}, nil
+
+	default:
+		return nil, fmt.Errorf("Bad request: %v", req)
 	}
 
-	return nil, fmt.Errorf("Bad request: %v", req)
+	return &pb.QueryRecordsResponse{InstanceIds: cleanAndValidateIids(ids)}, nil
 }
 
 // GetRecord gets a sigle record

--- a/recordcollectionapi_test.go
+++ b/recordcollectionapi_test.go
@@ -706,3 +706,41 @@ func TestCleanAndValidateIids(t *testing.T) {
 	}
 }
 
+func TestQueryRecordsWithNegativeId(t *testing.T) {
+	s := InitTestServer(".testqueryrecordsnegative")
+
+	var val uint32 = 2147937650
+	negID := int64(int32(val)) // -2147029646
+
+
+
+	collection, err := s.readRecordCollection(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to read record collection: %v", err)
+	}
+	if collection.InstanceToFolder == nil {
+		collection.InstanceToFolder = make(map[int64]int32)
+	}
+	collection.InstanceToFolder[negID] = 12
+	err = s.saveRecordCollection(context.Background(), collection)
+	if err != nil {
+		t.Fatalf("Failed to save record collection: %v", err)
+	}
+
+	q, err := s.QueryRecords(context.Background(), &pb.QueryRecordsRequest{
+		Query: &pb.QueryRecordsRequest_FolderId{FolderId: 12},
+	})
+	if err != nil {
+		t.Fatalf("QueryRecords failed: %v", err)
+	}
+
+	if len(q.GetInstanceIds()) != 1 {
+		t.Fatalf("Expected exactly 1 ID, got %v", len(q.GetInstanceIds()))
+	}
+
+	if q.GetInstanceIds()[0] != 2147937650 {
+		t.Errorf("Expected corrected ID 2147937650, got %v", q.GetInstanceIds()[0])
+	}
+}
+
+


### PR DESCRIPTION
Closes #9199. Closes #9200. Refactors QueryRecords in recordcollectionapi.go to remove redundant casts and cleans/validates the returned instance IDs using the cleanAndValidateIids helper function. Adds a unit test TestQueryRecordsWithNegativeId to cover this behavior.