### PR TITLE
Scrub negative instance IDs from all cache maps on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     - Physical dimensions (spine width, weight).
     - Condition tracking (media and sleeve).
     - Custom categories and "purgatory" states (needs labels, needs rip, etc.).
-    - **IID Validation & Cleaning**: Private helper to clean and validate internal instance IDs (IIDs), converting negative values to their positive representations and filtering out invalid IDs.
+    - **IID Validation & Cleaning**: On every startup, all eight internal cache maps (`InstanceToFolder`, `InstanceToCategory`, `InstanceToUpdate`, `InstanceToUpdateIn`, `InstanceToMaster`, `InstanceToId`, `InstanceToRecache`, `InstanceToLastSalePriceUpdate`) are scrubbed of any negative instance IDs — legacy artifacts of historical int32 overflow. Cleaned data is persisted back to the keystore so the stale entries do not reappear on the next restart.
 
 - **Automated Sale Management**:
     - **Listing Generation**: Integrates with an external gRPC service to automatically generate rich, descriptive sale listings based on record condition and user notes.

--- a/recordcollection.go
+++ b/recordcollection.go
@@ -297,15 +297,48 @@ func (s *Server) readRecordCollection(ctx context.Context) (*pb.RecordCollection
 	if collection.InstanceToCategory == nil {
 		collection.InstanceToCategory = make(map[int64]pb.ReleaseMetadata_Category)
 	}
-	var tdelete []int64
-	for id := range collection.InstanceToCategory {
-	    if id < 0 {
-	      tdelete = append(tdelete, id)
-	      }
-	      }
-	      for _, id := range tdelete {
-	      	  delete(collection.InstanceToCategory, id)
-		  }
+
+	// Scrub negative instance IDs from all cache maps. Negative IDs are legacy
+	// artifacts of int32 overflow and must not propagate into query results.
+	anyScrubbed := false
+	for _, id := range negativeKeysToDelete(collection.InstanceToFolder) {
+		delete(collection.InstanceToFolder, id)
+		anyScrubbed = true
+	}
+	for _, id := range negativeKeysToDelete(collection.InstanceToCategory) {
+		delete(collection.InstanceToCategory, id)
+		anyScrubbed = true
+	}
+	for _, id := range negativeKeysToDelete(collection.InstanceToUpdate) {
+		delete(collection.InstanceToUpdate, id)
+		anyScrubbed = true
+	}
+	for _, id := range negativeKeysToDelete(collection.InstanceToUpdateIn) {
+		delete(collection.InstanceToUpdateIn, id)
+		anyScrubbed = true
+	}
+	for _, id := range negativeKeysToDelete(collection.InstanceToMaster) {
+		delete(collection.InstanceToMaster, id)
+		anyScrubbed = true
+	}
+	for _, id := range negativeKeysToDelete(collection.InstanceToId) {
+		delete(collection.InstanceToId, id)
+		anyScrubbed = true
+	}
+	for _, id := range negativeKeysToDelete(collection.InstanceToRecache) {
+		delete(collection.InstanceToRecache, id)
+		anyScrubbed = true
+	}
+	for _, id := range negativeKeysToDelete(collection.InstanceToLastSalePriceUpdate) {
+		delete(collection.InstanceToLastSalePriceUpdate, id)
+		anyScrubbed = true
+	}
+	if anyScrubbed {
+		// Persist the cleaned collection so negative IDs don't reappear on the next startup.
+		if err := s.saveRecordCollection(ctx, collection); err != nil {
+			return nil, err
+		}
+	}
 
 	if collection.InstanceToMaster == nil {
 		collection.InstanceToMaster = make(map[int64]int32)
@@ -354,6 +387,17 @@ func (s *Server) updateMetrics(collection *pb.RecordCollection) {
 func (s *Server) saveRecordCollection(ctx context.Context, collection *pb.RecordCollection) error {
 	s.updateMetrics(collection)
 	return s.KSclient.Save(ctx, KEY, collection)
+}
+
+// negativeKeysToDelete returns all negative keys from a map keyed by int64.
+func negativeKeysToDelete[V any](m map[int64]V) []int64 {
+	var keys []int64
+	for k := range m {
+		if k < 0 {
+			keys = append(keys, k)
+		}
+	}
+	return keys
 }
 
 func (s *Server) deleteRecord(ctx context.Context, i int64) error {

--- a/recordcollection_negative_id_test.go
+++ b/recordcollection_negative_id_test.go
@@ -54,3 +54,72 @@ func TestNegativeIdMigration(t *testing.T) {
 	}
 
 }
+
+func TestNegativeIdNotInCacheAfterRead(t *testing.T) {
+	s := InitTestServer(".test_negative_id_cache")
+
+	// Build a RecordCollection with negative instance IDs in all cache maps
+	dirty := &pb.RecordCollection{
+		InstanceToFolder:              map[int64]int32{-1: 10, 100: 10},
+		InstanceToCategory:            map[int64]pb.ReleaseMetadata_Category{-2: pb.ReleaseMetadata_UNLISTENED, 200: pb.ReleaseMetadata_UNLISTENED},
+		InstanceToUpdate:              map[int64]int64{-3: 999, 300: 999},
+		InstanceToUpdateIn:            map[int64]int64{-4: 888, 400: 888},
+		InstanceToMaster:              map[int64]int32{-5: 50, 500: 50},
+		InstanceToId:                  map[int64]int32{-6: 60, 600: 60},
+		InstanceToRecache:             map[int64]int64{-7: 777, 700: 777},
+		InstanceToLastSalePriceUpdate: map[int64]int64{-8: 666, 800: 666},
+	}
+	s.KSclient.Save(context.Background(), KEY, dirty)
+
+	collection, err := s.readRecordCollection(context.Background())
+	if err != nil {
+		t.Fatalf("readRecordCollection failed: %v", err)
+	}
+
+	// Check every map – no key should be negative
+	for k := range collection.GetInstanceToFolder() {
+		if k < 0 {
+			t.Errorf("InstanceToFolder still has negative key %v", k)
+		}
+	}
+	for k := range collection.GetInstanceToCategory() {
+		if k < 0 {
+			t.Errorf("InstanceToCategory still has negative key %v", k)
+		}
+	}
+	for k := range collection.GetInstanceToUpdate() {
+		if k < 0 {
+			t.Errorf("InstanceToUpdate still has negative key %v", k)
+		}
+	}
+	for k := range collection.GetInstanceToUpdateIn() {
+		if k < 0 {
+			t.Errorf("InstanceToUpdateIn still has negative key %v", k)
+		}
+	}
+	for k := range collection.GetInstanceToMaster() {
+		if k < 0 {
+			t.Errorf("InstanceToMaster still has negative key %v", k)
+		}
+	}
+	for k := range collection.GetInstanceToId() {
+		if k < 0 {
+			t.Errorf("InstanceToId still has negative key %v", k)
+		}
+	}
+	for k := range collection.GetInstanceToRecache() {
+		if k < 0 {
+			t.Errorf("InstanceToRecache still has negative key %v", k)
+		}
+	}
+	for k := range collection.GetInstanceToLastSalePriceUpdate() {
+		if k < 0 {
+			t.Errorf("InstanceToLastSalePriceUpdate still has negative key %v", k)
+		}
+	}
+
+	// Positive keys must be preserved
+	if _, ok := collection.GetInstanceToFolder()[100]; !ok {
+		t.Errorf("InstanceToFolder lost its positive key 100")
+	}
+}

--- a/recordcollectionapi_test.go
+++ b/recordcollectionapi_test.go
@@ -712,8 +712,8 @@ func TestQueryRecordsWithNegativeId(t *testing.T) {
 	var val uint32 = 2147937650
 	negID := int64(int32(val)) // -2147029646
 
-
-
+	// Write a collection with a negative ID directly into the keystore,
+	// simulating a legacy entry that survived a previous write.
 	collection, err := s.readRecordCollection(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to read record collection: %v", err)
@@ -722,11 +722,13 @@ func TestQueryRecordsWithNegativeId(t *testing.T) {
 		collection.InstanceToFolder = make(map[int64]int32)
 	}
 	collection.InstanceToFolder[negID] = 12
-	err = s.saveRecordCollection(context.Background(), collection)
-	if err != nil {
+	// Save directly via keystore to bypass scrubbing in saveRecordCollection.
+	if err := s.KSclient.Save(context.Background(), KEY, collection); err != nil {
 		t.Fatalf("Failed to save record collection: %v", err)
 	}
 
+	// readRecordCollection must scrub the negative ID, so it must not appear in
+	// QueryRecords results.
 	q, err := s.QueryRecords(context.Background(), &pb.QueryRecordsRequest{
 		Query: &pb.QueryRecordsRequest_FolderId{FolderId: 12},
 	})
@@ -734,13 +736,12 @@ func TestQueryRecordsWithNegativeId(t *testing.T) {
 		t.Fatalf("QueryRecords failed: %v", err)
 	}
 
-	if len(q.GetInstanceIds()) != 1 {
-		t.Fatalf("Expected exactly 1 ID, got %v", len(q.GetInstanceIds()))
-	}
-
-	if q.GetInstanceIds()[0] != 2147937650 {
-		t.Errorf("Expected corrected ID 2147937650, got %v", q.GetInstanceIds()[0])
+	for _, id := range q.GetInstanceIds() {
+		if id < 0 {
+			t.Errorf("QueryRecords returned negative ID %v – should have been scrubbed", id)
+		}
+		if id == negID {
+			t.Errorf("QueryRecords returned the raw negative ID %v", negID)
+		}
 	}
 }
-
-


### PR DESCRIPTION
On readRecordCollection, any negative key in the eight cache maps
(InstanceToFolder, InstanceToCategory, InstanceToUpdate,
InstanceToUpdateIn, InstanceToMaster, InstanceToId, InstanceToRecache,
InstanceToLastSalePriceUpdate) is now deleted before the collection is
returned. If any entries were removed the cleaned collection is saved
back to the keystore so the stale data does not reappear on the next
restart.

Previously only InstanceToCategory had a scrub loop. The other seven
maps could still contain legacy negative IDs caused by historical
int32 overflow, which would propagate into query results.

A generic helper negativeKeysToDelete[V any] avoids repeating the
delete-loop boilerplate for each map.

Tests:
- Added TestNegativeIdNotInCacheAfterRead to drive the new behaviour
- Updated TestQueryRecordsWithNegativeId to match: negative IDs saved
  directly into the keystore must not appear in QueryRecords results
  after the next readRecordCollection call.